### PR TITLE
Fix preceedingLineNum index

### DIFF
--- a/src/obsidian-text-editor.ts
+++ b/src/obsidian-text-editor.ts
@@ -68,9 +68,9 @@ export class ObsidianTextEditor {
     // Check that the text `-tx-` is not on the line immediately preceeding the
     // table found in the previous check.
     // https://github.com/tgrosinger/advanced-tables-obsidian/issues/133
-    const preceedingLineNum = table.position.start.line - 1;
-    if (preceedingLineNum >= 0) {
-      const preceedingLine = this.getLine(preceedingLineNum);
+    const preceedingLineIndex = table.position.start.line;
+    if (preceedingLineIndex >= 0) {
+      const preceedingLine = this.getLine(preceedingLineIndex);
       if (preceedingLine === '-tx-') {
         return false;
       }


### PR DESCRIPTION
Obsidian counts table position start line from first non blank line above the table. And table.position.start.line is the index of that line.

Fixes #133
Fixes #130