### PR TITLE
Remove outdated warning from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Advanced Tables for Obsidian
 
-⚠️ **Note:** This plugin works in **Live Preview** mode, however will appear to be rendering incorrectly. See [this issue](https://github.com/tgrosinger/advanced-tables-obsidian/issues/145) for more details.
-
 Add improved navigation, formatting, and manipulation to markdown tables in Obsidian:
 
 - Auto formatting


### PR DESCRIPTION
The issue has been fixed (https://github.com/tgrosinger/advanced-tables-obsidian/issues/145#issuecomment-1081828494) and there is support for updating the readme (https://github.com/tgrosinger/advanced-tables-obsidian/issues/145#issuecomment-1087632885) to remove this line.