### PR TITLE
Fix code blocks width in tables

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2,6 +2,11 @@
   --advanced-tables-helper-size: 28px;
 }
 
+.HyperMD-table-row span.cm-inline-code {
+  font-size: 100%;
+  padding: 0px;
+}
+
 .advanced-tables-buttons>div>.title {
   font-weight: var(--font-medium);
   font-size: var(--nav-item-size);


### PR DESCRIPTION
This fixes issue #56, which was originally fixed by commit a083a034db1c, but it seems the fix has been accidentally removed by 400cfbc096. I also set padding to 0px, because cm-inline-code now sets it to 1px, which breaks the alignment.