### PR TITLE
Allow tables to be detected properly when inside of obsidian callouts

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -34,6 +34,9 @@ export class TableEditorPluginSettings implements ISettings {
   }
 
   public asOptions(): Options {
-    return optionsWithDefaults({ formatType: this.formatType });
+    return optionsWithDefaults({
+      formatType: this.formatType,
+      leftMarginChars: new Set(['>']),
+    });
   }
 }


### PR DESCRIPTION
Simply adds the `>` to the `leftMarginChars` by default. This allows md-advance-tables to detect tables inside of Obsidian callouts. Formatting of these kinds of tables is still broken and will need to be fixed in the upstream @tgrosinger/md-advance-tables repo.

Tested in a vault with non-trivial (~50 files with callout-enclosed tables) usage and noticed no adverse affects.

Please advise if any additional work or testing is required, thanks for your consideration.